### PR TITLE
Adding Search Track by Artist support

### DIFF
--- a/client/src/components/SearchTypeSelector.jsx
+++ b/client/src/components/SearchTypeSelector.jsx
@@ -2,6 +2,12 @@ import React from "react";
 
 import { Form } from "react-bootstrap";
 
+import {
+	TYPE_TRACKS,
+	TYPE_ARTISTS,
+	TYPE_PLAYLISTS,
+} from "../constants/searchTypeConstants";
+
 const SearchTypeSelector = ({ setType }) => {
 	return (
 		<Form.Group>
@@ -11,8 +17,9 @@ const SearchTypeSelector = ({ setType }) => {
 				onChange={(e) => setType(e.target.value)}
 				defaultValue='tracks'
 			>
-				<option value='tracks'>Tracks</option>
-				<option value='playlists'>Playlists</option>
+				<option value={TYPE_TRACKS}>Tracks</option>
+				<option value={TYPE_ARTISTS}>Artists</option>
+				<option value={TYPE_PLAYLISTS}>Playlists</option>
 			</Form.Control>
 		</Form.Group>
 	);

--- a/client/src/components/TrackSearchResult.jsx
+++ b/client/src/components/TrackSearchResult.jsx
@@ -16,9 +16,12 @@ const TrackSearchResult = ({ track, chooseTrack }) => {
 				className='mr-3'
 				alt={track.title}
 				onClick={handlePlay}
+				style={cursorStyle}
 			/>
 			<Media.Body>
-				<h6 onClick={handlePlay}>{track.title}</h6>
+				<h6 onClick={handlePlay} className='p2' style={cursorStyle}>
+					{track.title}
+				</h6>
 				<div>
 					{track.artistNames.map((artist, i) => (
 						<Badge
@@ -34,5 +37,7 @@ const TrackSearchResult = ({ track, chooseTrack }) => {
 		</Media>
 	);
 };
+
+const cursorStyle = { cursor: "pointer" };
 
 export default TrackSearchResult;

--- a/client/src/components/TrackSearchResult.jsx
+++ b/client/src/components/TrackSearchResult.jsx
@@ -8,20 +8,16 @@ const TrackSearchResult = ({ track, chooseTrack }) => {
 	};
 
 	return (
-		<Media className='m-2'>
+		<Media className='m-2' style={cursorStyle} onClick={handlePlay}>
 			<img
 				src={track.albumUrl}
 				width={64}
 				height={64}
 				className='mr-3'
 				alt={track.title}
-				onClick={handlePlay}
-				style={cursorStyle}
 			/>
 			<Media.Body>
-				<h6 onClick={handlePlay} className='p2' style={cursorStyle}>
-					{track.title}
-				</h6>
+				<h6 className='p2'>{track.title}</h6>
 				<div>
 					{track.artistNames.map((artist, i) => (
 						<Badge

--- a/client/src/components/TrackSearchResult.jsx
+++ b/client/src/components/TrackSearchResult.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Badge } from "react-bootstrap";
+import { Badge, Media } from "react-bootstrap";
 
 const TrackSearchResult = ({ track, chooseTrack }) => {
 	const handlePlay = () => {
@@ -8,27 +8,30 @@ const TrackSearchResult = ({ track, chooseTrack }) => {
 	};
 
 	return (
-		<div
-			className='d-flex m-2 align-items-center'
-			style={{ cursor: "pointer" }}
-			onClick={handlePlay}
-		>
+		<Media className='m-2'>
 			<img
 				src={track.albumUrl}
-				style={{ height: "64px", width: "64px" }}
+				width={64}
+				height={64}
+				className='mr-3'
 				alt={track.title}
+				onClick={handlePlay}
 			/>
-			<div className='ml-3'>
-				<div>{track.title}</div>
-				<div className='text-muted'>
+			<Media.Body>
+				<h6 onClick={handlePlay}>{track.title}</h6>
+				<div>
 					{track.artistNames.map((artist, i) => (
-						<Badge variant='dark' key={i} className='m-1'>
+						<Badge
+							variant={i === 0 ? "primary" : "dark"}
+							key={i}
+							className='m-1'
+						>
 							{artist}
 						</Badge>
 					))}
 				</div>
-			</div>
-		</div>
+			</Media.Body>
+		</Media>
 	);
 };
 

--- a/client/src/constants/searchTypeConstants.js
+++ b/client/src/constants/searchTypeConstants.js
@@ -1,0 +1,3 @@
+export const TYPE_TRACKS = "TYPE_TRACKS";
+export const TYPE_ARTISTS = "TYPE_ARTISTS";
+export const TYPE_PLAYLISTS = "TYPE_PLAYLISTS";

--- a/client/src/screens/DashboardScreen.jsx
+++ b/client/src/screens/DashboardScreen.jsx
@@ -117,6 +117,32 @@ const DashboardScreen = ({ code }) => {
 				});
 				break;
 			case TYPE_ARTISTS:
+				spotifyWebAPI.searchTracks(`artist:${searchTerms}`).then((res) => {
+					if (cancelSearch) return;
+
+					setSearchResults(
+						res.body.tracks.items.map((track) => {
+							const smallestAlbumArt = track.album.images.reduce(
+								(smallest, image) => {
+									if (image.height < smallest) return image;
+									return smallest;
+								},
+								track.album.images[0]
+							);
+
+							const trackArtists = track.artists.map((artist) => {
+								return artist.name;
+							});
+
+							return {
+								artistNames: trackArtists,
+								title: track.name,
+								uri: track.uri,
+								albumUrl: smallestAlbumArt.url,
+							};
+						})
+					);
+				});
 				break;
 			default:
 				spotifyWebAPI.searchTracks(searchTerms).then((res) => {

--- a/client/src/screens/DashboardScreen.jsx
+++ b/client/src/screens/DashboardScreen.jsx
@@ -10,6 +10,12 @@ import SearchBox from "../components/SearchBox";
 import useAuth from "../hooks/useAuth";
 import SearchTypeSelector from "../components/SearchTypeSelector";
 
+import {
+	TYPE_TRACKS,
+	TYPE_ARTISTS,
+	TYPE_PLAYLISTS,
+} from "../constants/searchTypeConstants";
+
 const spotifyWebAPI = new SpotifyWebApi({
 	clientId: process.env.REACT_APP_SPOTIFY_CLIENT_ID,
 	clientSecret: process.env.REACT_APP_SPOTIFY_CLIENT_SECRET,
@@ -18,7 +24,7 @@ const spotifyWebAPI = new SpotifyWebApi({
 const DashboardScreen = ({ code }) => {
 	const accessToken = useAuth(code);
 
-	const [searchType, setSearchType] = useState("tracks");
+	const [searchType, setSearchType] = useState(TYPE_TRACKS);
 	const [searchTerms, setSearchTerms] = useState("");
 	const [searchResults, setSearchResults] = useState([]);
 	const [playingTrack, setPlayingTrack] = useState();
@@ -58,7 +64,7 @@ const DashboardScreen = ({ code }) => {
 
 		let cancelSearch = false;
 		switch (searchType) {
-			case "tracks":
+			case TYPE_TRACKS:
 				spotifyWebAPI.searchTracks(searchTerms).then((res) => {
 					if (cancelSearch) return;
 
@@ -86,7 +92,7 @@ const DashboardScreen = ({ code }) => {
 					);
 				});
 				break;
-			case "playlists":
+			case TYPE_PLAYLISTS:
 				spotifyWebAPI.searchPlaylists(searchTerms).then((res) => {
 					if (cancelSearch) return;
 
@@ -109,6 +115,8 @@ const DashboardScreen = ({ code }) => {
 						})
 					);
 				});
+				break;
+			case TYPE_ARTISTS:
 				break;
 			default:
 				spotifyWebAPI.searchTracks(searchTerms).then((res) => {


### PR DESCRIPTION
# Adding the functionality search tracks by a given artist name.

This is done by adding a new dropdown in the Search Types and modifying the search logic in the useEffect.

* Outside of this, I also moved the Search Types into a separate constants file to make adding more Types easier in the future.